### PR TITLE
fix: invalid url

### DIFF
--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -23,7 +23,7 @@
   ],
   "topbarCtaButton": {
     "name": "Dashboard",
-    "url": "https://apps.unsend.dev"
+    "url": "https://app.unsend.dev"
   },
   "tabs": [
     {


### PR DESCRIPTION
This fixes the invalid url when pressing "dashboard" on the docs page
![CleanShot 2024-07-19 at 20 49 41@2x](https://github.com/user-attachments/assets/d54f5902-0859-4ef1-b5b8-1b83f8c1b2f0)
