### PR TITLE
update dkim to have smaller key

### DIFF
--- a/apps/web/src/server/aws/ses.ts
+++ b/apps/web/src/server/aws/ses.ts
@@ -28,7 +28,7 @@ function getSesClient(region: string) {
 
 function generateKeyPair() {
   const { privateKey, publicKey } = generateKeyPairSync("rsa", {
-    modulusLength: 2048, // Length of your key in bits
+    modulusLength: 1024, // Length of your key in bits
     publicKeyEncoding: {
       type: "spki", // Recommended to be 'spki' by the Node.js docs
       format: "pem",


### PR DESCRIPTION
- some dns provider has restriction with txt record being more than 255 chars. 
- so reduced the size of the key pair