### PR TITLE
Prevent getQuotaForRegion when region undefined

### DIFF
--- a/apps/web/src/app/(dashboard)/dev-settings/api-keys/add-api-key.tsx
+++ b/apps/web/src/app/(dashboard)/dev-settings/api-keys/add-api-key.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@unsend/ui/src/button";
 import { Input } from "@unsend/ui/src/input";
-import { Label } from "@unsend/ui/src/label";
 import {
   Dialog,
   DialogContent,

--- a/apps/web/src/app/(dashboard)/dev-settings/settings-nav-button.tsx
+++ b/apps/web/src/app/(dashboard)/dev-settings/settings-nav-button.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { LogOut } from "lucide-react";
-import { signOut } from "next-auth/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import React from "react";

--- a/apps/web/src/app/(dashboard)/domains/[domainId]/delete-domain.tsx
+++ b/apps/web/src/app/(dashboard)/domains/[domainId]/delete-domain.tsx
@@ -2,15 +2,12 @@
 
 import { Button } from "@unsend/ui/src/button";
 import { Input } from "@unsend/ui/src/input";
-import { Label } from "@unsend/ui/src/label";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
+  DialogDescription, DialogHeader,
   DialogTitle,
-  DialogTrigger,
+  DialogTrigger
 } from "@unsend/ui/src/dialog";
 
 import {

--- a/apps/web/src/app/login/login-page.tsx
+++ b/apps/web/src/app/login/login-page.tsx
@@ -22,8 +22,7 @@ import {
   REGEXP_ONLY_DIGITS_AND_CHARS,
 } from "@unsend/ui/src/input-otp";
 import { Input } from "@unsend/ui/src/input";
-import { env } from "~/env";
-import { BuiltInProviderType, Provider } from "next-auth/providers/index";
+import { BuiltInProviderType } from "next-auth/providers/index";
 import Spinner from "@unsend/ui/src/spinner";
 import Link from "next/link";
 import { useTheme } from "@unsend/ui";

--- a/apps/web/src/app/unsubscribe/page.tsx
+++ b/apps/web/src/app/unsubscribe/page.tsx
@@ -1,8 +1,5 @@
-import { Button } from "@unsend/ui/src/button";
-import { Suspense } from "react";
 import {
   unsubscribeContact,
-  subscribeContact,
 } from "~/server/service/campaign-service";
 import ReSubscribe from "./re-subscribe";
 export const dynamic = "force-dynamic";

--- a/apps/web/src/components/settings/AddSesSettings.tsx
+++ b/apps/web/src/components/settings/AddSesSettings.tsx
@@ -94,8 +94,11 @@ export const AddSesSettingsForm: React.FC<SesSettingsProps> = ({
 
   const onRegionInputOutOfFocus = async () => {
     const region = form.getValues("region");
-    const quota = await utils.admin.getQuotaForRegion.fetch({ region });
-    form.setValue("sendRate", quota ?? 1);
+
+    if (region) {
+      const quota = await utils.admin.getQuotaForRegion.fetch({ region });
+      form.setValue("sendRate", quota ?? 1);
+    }
   };
 
   return (


### PR DESCRIPTION
`onRegionInputOutOfFocus` calls `utils.admin.getQuotaForRegion.fetch({ region });` but region is undefined initially, which is not appreciated upstream.

A suggested future change would be to expose the `AWS_DEFAULT_REGION` variable as a public env and use that as the default value instead of the placeholder.

![Screenshot 2025-02-10 at 11 12 30 AM](https://github.com/user-attachments/assets/1020390b-184e-4f0c-9213-de0eb247b121)
![Screenshot 2025-02-10 at 11 12 44 AM](https://github.com/user-attachments/assets/62473f4b-78a5-493a-b31c-8999e0f9c01b)

Also removed some unused imports that I came across.