### PR TITLE
Fix Node SDK initialization docs

### DIFF
--- a/apps/docs/get-started/nodejs.mdx
+++ b/apps/docs/get-started/nodejs.mdx
@@ -38,7 +38,14 @@ icon: node-js
     ```javascript
     import { Unsend } from "unsend";
 
-    const unsend = new Unsend({ apiKey: "us_12345" });
+    const unsend = new Unsend("us_12345");
+    ```
+
+    If you are running a self-hosted version of Unsend, pass the base URL as the
+    second argument:
+
+    ```javascript
+    const unsend = new Unsend("us_12345", "https://my-unsend-instance.com");
     ```
 
   </Step>

--- a/apps/docs/guides/use-with-react-email.mdx
+++ b/apps/docs/guides/use-with-react-email.mdx
@@ -53,7 +53,7 @@ import { Unsend } from "unsend";
 import { render } from "@react-email/render";
 import { Email } from "./email";
 
-const unsend = new Unsend({ apiKey: "us_your_unsend_api_key" });
+const unsend = new Unsend("us_your_unsend_api_key");
 
   const html = await render(<Email url="https://unsend.dev" />);
 

--- a/apps/web/src/lib/constants/example-codes.ts
+++ b/apps/web/src/lib/constants/example-codes.ts
@@ -19,7 +19,9 @@ export const getSendTestEmailCode = ({
       title: "Node.js",
       code: `import { Unsend } from "unsend";
 
-const unsend = new Unsend({ apiKey: "us_12345" });
+const unsend = new Unsend("us_12345");
+
+// const unsend = new Unsend("us_12345", "https://my-unsend-instance.com");
 
 unsend.emails.send({
   to: "${to}",

--- a/packages/email-editor/src/editor.tsx
+++ b/packages/email-editor/src/editor.tsx
@@ -49,7 +49,9 @@ You can create unordered list
 <p>Add code by typing \`\`\` and enter</p>
 <pre>
 <code>
-const unsend = new Unsend({ apiKey: "us_12345" });
+const unsend = new Unsend("us_12345");
+
+// const unsend = new Unsend("us_12345", "https://my-unsend-instance.com");
 
 unsend.emails.send({
   to: "john@doe.com",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -36,7 +36,10 @@ bun add unsend
 ```javascript
 import { Unsend } from "unsend";
 
-const unsend = new Unsend({ apiKey: "us_12345" });
+const unsend = new Unsend("us_12345");
+
+// for self-hosted installations you can pass your base URL
+// const unsend = new Unsend("us_12345", "https://my-unsend-instance.com");
 
 unsend.emails.send({
   to: "hello@acme.com",


### PR DESCRIPTION
## Summary
- correct SDK initialization syntax in Node.js docs
- mention optional URL argument for self-hosting
- update React Email guide and examples
- document self-hosted URL usage in README

## Testing
- `npx prettier --write apps/docs/get-started/nodejs.mdx apps/docs/guides/use-with-react-email.mdx packages/sdk/README.md apps/web/src/lib/constants/example-codes.ts packages/email-editor/src/editor.tsx`