### PR TITLE
Implement per-team API rate limiting with Redis

### DIFF
--- a/apps/web/prisma/migrations/20250517053539_add_team_api_rate_limit/migration.sql
+++ b/apps/web/prisma/migrations/20250517053539_add_team_api_rate_limit/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Team" ADD COLUMN "apiRateLimit" INTEGER NOT NULL DEFAULT 2;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -104,6 +104,7 @@ model Team {
   plan             Plan              @default(FREE)
   stripeCustomerId String?           @unique
   isActive         Boolean           @default(true)
+  apiRateLimit     Int               @default(2)
   billingEmail     String?
   teamUsers        TeamUser[]
   domains          Domain[]


### PR DESCRIPTION
## Summary
- introduce `apiRateLimit` setting on teams
- enforce API rate limits with Redis when running in cloud mode
- keep env-based TTL cache rate limiting for self-hosted setups
- add migration for new `Team.apiRateLimit` column

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*
- `pnpm d` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.9.0.tgz)*