### PR TITLE
docs: link coolify blog

### DIFF
--- a/apps/docs/get-started/self-hosting.mdx
+++ b/apps/docs/get-started/self-hosting.mdx
@@ -199,3 +199,7 @@ You're all set up now.
 - Start sending emails.
 
 If you have any questions, please join [#self-host](https://discord.gg/gbsvjb9MqV) on discord.
+
+<Tip>
+A community member shared a short write-up on hosting Unsend with [Coolify](https://mattstein.com/thoughts/coolify-unsend/). Give it a read if you need another reference.
+</Tip>


### PR DESCRIPTION
## Summary
- add a callout linking to a community guide on hosting Unsend with Coolify

## Testing
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffe33c62083299f551a70ad58c904