### PR TITLE
Reduce horizontal padding for mobile layout

### DIFF
--- a/apps/web/src/app/(dashboard)/dasboard-layout.tsx
+++ b/apps/web/src/app/(dashboard)/dasboard-layout.tsx
@@ -13,7 +13,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
       <SidebarProvider>
         <AppSidebar />
         <SidebarInset>
-          <main className="flex-1 overflow-auto h-full p-4 px-40">
+          <main className="flex-1 overflow-auto h-full p-4 xl:px-40">
             {isMobile ? (
               <SidebarTrigger className="h-5 w-5 text-muted-foreground" />
             ) : null}


### PR DESCRIPTION
This is a quick padding improvement that makes the dashboard more usable at narrow viewports, so that the larger 10rem padding only applies when there’s a minimum width of 1280px.

<table>
<thead>
<th>Before</th>
<th>After</th>
</thead>
<tbody>
<tr>
<td><img src="https://github.com/user-attachments/assets/a70ff230-a150-4f91-9449-d16db6654875" alt="layout before the change" /></td>
<td><img src="https://github.com/user-attachments/assets/238eace6-ed02-42cb-8e87-040200390bcb" alt="layout after the change" /></td>
</tr>
</tbody>
</table>
