### PR TITLE
Fix domain parsing undefined value

### DIFF
--- a/apps/web/src/server/service/domain-service.ts
+++ b/apps/web/src/server/service/domain-service.ts
@@ -9,9 +9,17 @@ import { UnsendApiError } from "../public-api/api-error";
 const dnsResolveTxt = util.promisify(dns.resolveTxt);
 
 export async function validateDomainFromEmail(email: string, teamId: number) {
-// Extract email from format like 'Name <email@domain>' this will allow entries such as "Someone @ something <some@domain.com>" to parse correctly as well.
-const match = email.match(/<([^>]+)>/);
-let fromDomain = match ? match[1].split("@")[1] : email.split("@")[1];
+  // Extract email from format like 'Name <email@domain>' this will allow entries such as "Someone @ something <some@domain.com>" to parse correctly as well.
+  const match = email.match(/<([^>]+)>/);
+  let fromDomain: string | undefined;
+
+  if (match && match[1]) {
+    const parts = match[1].split("@");
+    fromDomain = parts.length > 1 ? parts[1] : undefined;
+  } else {
+    const parts = email.split("@");
+    fromDomain = parts.length > 1 ? parts[1] : undefined;
+  }
 
   if (fromDomain?.endsWith(">")) {
     fromDomain = fromDomain.slice(0, -1);


### PR DESCRIPTION
## Summary
- fix undefined domain error in `validateDomainFromEmail`

## Testing
- `pnpm install`
- `pnpm lint` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_685003239e588329a19b9cda221138f8