### PR TITLE
fix: team invitation links not working properly

### DIFF
--- a/apps/web/src/app/join-team/page.tsx
+++ b/apps/web/src/app/join-team/page.tsx
@@ -4,11 +4,16 @@ import Spinner from "@unsend/ui/src/spinner";
 import { getServerAuthSession } from "~/server/auth";
 import { redirect } from "next/navigation";
 
-export default async function CreateTeam() {
+export default async function CreateTeam({
+  searchParams,
+}: {
+  searchParams: { inviteId?: string };
+}) {
   const session = await getServerAuthSession();
 
   if (!session) {
-    redirect("/login");
+    const inviteId = searchParams?.inviteId;
+    redirect(`/login${inviteId ? `?inviteId=${inviteId}` : ""}`);
   }
 
   return (

--- a/apps/web/src/app/login/login-page.tsx
+++ b/apps/web/src/app/login/login-page.tsx
@@ -26,6 +26,7 @@ import { BuiltInProviderType } from "next-auth/providers/index";
 import Spinner from "@unsend/ui/src/spinner";
 import Link from "next/link";
 import { useTheme } from "@unsend/ui";
+import { useSearchParams as useNextSearchParams } from "next/navigation";
 
 const emailSchema = z.object({
   email: z
@@ -93,9 +94,10 @@ export default function LoginPage({
     const email = emailForm.getValues().email;
     console.log("email", email);
 
+    const finalCallbackUrl = inviteId ? `/join-team?inviteId=${inviteId}` : `${callbackUrl}/dashboard`;
     window.location.href = `/api/auth/callback/email?email=${encodeURIComponent(
       email.toLowerCase()
-    )}&token=${values.otp.toLowerCase()}${callbackUrl ? `&callbackUrl=${callbackUrl}/dashboard` : ""}`;
+    )}&token=${values.otp.toLowerCase()}&callbackUrl=${encodeURIComponent(finalCallbackUrl)}`;
   }
 
   const emailProvider = providers?.find(
@@ -104,10 +106,14 @@ export default function LoginPage({
 
   const [submittedProvider, setSubmittedProvider] =
     useState<LiteralUnion<BuiltInProviderType> | null>(null);
+  
+  const searchParams = useNextSearchParams();
+  const inviteId = searchParams.get("inviteId");
 
   const handleSubmit = (provider: LiteralUnion<BuiltInProviderType>) => {
     setSubmittedProvider(provider);
-    signIn(provider);
+    const callbackUrl = inviteId ? `/join-team?inviteId=${inviteId}` : "/dashboard";
+    signIn(provider, { callbackUrl });
   };
 
   const { resolvedTheme } = useTheme();

--- a/apps/web/src/server/auth.ts
+++ b/apps/web/src/server/auth.ts
@@ -53,6 +53,11 @@ function getProviders() {
         clientId: env.GITHUB_ID,
         clientSecret: env.GITHUB_SECRET,
         allowDangerousEmailAccountLinking: true,
+        authorization: {
+          params: {
+            scope: 'read:user user:email'
+          }
+        }
       })
     );
   }


### PR DESCRIPTION
## Summary
- Fixed GitHub OAuth to request user:email scope for reliable email retrieval
- Preserved inviteId parameter through the entire authentication flow
- Updated redirect logic to maintain invitation context

## Problem
When team members clicked invitation links and logged in with GitHub, they would:
1. Lose the inviteId parameter during authentication
2. Get redirected to "Create Team" page instead of accepting the invitation
3. See "No invites found" message when visiting the link again

## Root Causes
1. GitHub OAuth provider wasn't requesting the user:email scope, resulting in null email for users with private GitHub emails
2. The inviteId parameter was lost during the OAuth redirect flow
3. The join-team page didn't preserve inviteId when redirecting unauthenticated users to login

## Solution
- Added `user:email` scope to GitHub OAuth configuration to ensure email is always retrieved
- Modified login page to preserve inviteId in OAuth and email callbacks
- Updated join-team page to pass inviteId when redirecting to login

## Test Plan
1. Create a team invitation link
2. Open in private browser
3. Click the link and login with GitHub
4. Verify you're redirected back to the invitation acceptance page
5. Accept the invitation and verify you join the team successfully

Fixes #177

🤖 Generated with [Claude Code](https://claude.ai/code)