### PR TITLE
feat: reload SMTP server TLS certificates on change

### DIFF
--- a/apps/smtp-server/src/server.ts
+++ b/apps/smtp-server/src/server.ts
@@ -2,7 +2,7 @@ import { SMTPServer, SMTPServerOptions, SMTPServerSession } from "smtp-server";
 import { Readable } from "stream";
 import dotenv from "dotenv";
 import { simpleParser } from "mailparser";
-import { readFileSync } from "fs";
+import { readFileSync, watch } from "fs";
 
 dotenv.config();
 
@@ -33,10 +33,10 @@ async function sendEmailToUnsend(emailData: any, apiKey: string) {
       console.error(
         "Unsend API error response: error:",
         JSON.stringify(errorData, null, 4),
-        `\nemail data: ${emailDataText}`
+        `\nemail data: ${emailDataText}`,
       );
       throw new Error(
-        `Failed to send email: ${errorData || "Unknown error from server"}`
+        `Failed to send email: ${errorData || "Unknown error from server"}`,
       );
     }
 
@@ -53,14 +53,23 @@ async function sendEmailToUnsend(emailData: any, apiKey: string) {
   }
 }
 
+function loadCertificates(): { key?: Buffer; cert?: Buffer } {
+  return {
+    key: SSL_KEY_PATH ? readFileSync(SSL_KEY_PATH) : undefined,
+    cert: SSL_CERT_PATH ? readFileSync(SSL_CERT_PATH) : undefined,
+  };
+}
+
+const initialCerts = loadCertificates();
+
 const serverOptions: SMTPServerOptions = {
   secure: false,
-  key: SSL_KEY_PATH ? readFileSync(SSL_KEY_PATH) : undefined,
-  cert: SSL_CERT_PATH ? readFileSync(SSL_CERT_PATH) : undefined,
+  key: initialCerts.key,
+  cert: initialCerts.cert,
   onData(
     stream: Readable,
     session: SMTPServerSession,
-    callback: (error?: Error) => void
+    callback: (error?: Error) => void,
   ) {
     console.log("Receiving email data..."); // Debug statement
     simpleParser(stream, (err, parsed) => {
@@ -109,6 +118,8 @@ const serverOptions: SMTPServerOptions = {
 };
 
 function startServers() {
+  const servers: SMTPServer[] = [];
+
   if (SSL_KEY_PATH && SSL_CERT_PATH) {
     // Implicit SSL/TLS for ports 465 and 2465
     [465, 2465].forEach((port) => {
@@ -116,13 +127,15 @@ function startServers() {
 
       server.listen(port, () => {
         console.log(
-          `Implicit SSL/TLS SMTP server is listening on port ${port}`
+          `Implicit SSL/TLS SMTP server is listening on port ${port}`,
         );
       });
 
       server.on("error", (err) => {
         console.error(`Error occurred on port ${port}:`, err);
       });
+
+      servers.push(server);
     });
   }
 
@@ -137,7 +150,27 @@ function startServers() {
     server.on("error", (err) => {
       console.error(`Error occurred on port ${port}:`, err);
     });
+
+    servers.push(server);
   });
+
+  if (SSL_KEY_PATH && SSL_CERT_PATH) {
+    const reloadCertificates = () => {
+      try {
+        const { key, cert } = loadCertificates();
+        if (key && cert) {
+          servers.forEach((srv) => srv.updateSecureContext({ key, cert }));
+          console.log("TLS certificates reloaded");
+        }
+      } catch (err) {
+        console.error("Failed to reload TLS certificates", err);
+      }
+    };
+
+    [SSL_KEY_PATH, SSL_CERT_PATH].forEach((file) => {
+      watch(file, { persistent: false }, reloadCertificates);
+    });
+  }
 }
 
 startServers();


### PR DESCRIPTION
## Summary
- watch TLS key/cert files for changes
- reload secure context for all SMTP server instances when certs update

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config in packages/sdk and @unsend/ui)*
- `pnpm lint --filter=./apps/smtp-server`
- `pnpm build --filter=./apps/smtp-server`

------
https://chatgpt.com/codex/tasks/task_e_68b2a1beb8d883298cc609f39a6ff537